### PR TITLE
fix: stay on signup page and show toast on failure (closes #28)

### DIFF
--- a/Athlead-client/src/pages/Signup.jsx
+++ b/Athlead-client/src/pages/Signup.jsx
@@ -20,22 +20,24 @@ const Signup = () => {
   const navigate = useNavigate();
 
   const onSubmit = async (data) => {
-    // Formatting Date from DD-MM-YYYY to YYYY-MM-DD
     const formattedData = { ...data };
     if (data.DOB) {
       const [day, month, year] = data.DOB.split("/");
       formattedData.DOB = `${year}-${month}-${day}`;
     }
 
-    const res = await api.post("/api/auth/signup", formattedData);
+    try {
+      const res = await api.post("/api/auth/signup", formattedData);
 
-    if (res.data.success) {
-      toast.success(res.data.message);
-    } else {
-      toast.error(res.data.message);
+      if (res.data.success) {
+        toast.success(res.data.message);
+        navigate("/login");
+      } else {
+        toast.error(res.data.message);
+      }
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Signup failed. Please try again.");
     }
-
-    navigate("/login");
   };
   return (
     <section className="dark-bg relative max-w-screen min-h-screen flex items-center justify-center bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[60px_60px] bg-repeat overflow-hidden">

--- a/Athlead-client/src/pages/Signup.jsx
+++ b/Athlead-client/src/pages/Signup.jsx
@@ -33,10 +33,12 @@ const Signup = () => {
         toast.success(res.data.message);
         navigate("/login");
       } else {
-        toast.error(res.data.message);
+        toast.error(res.data.message || "Signup failed. Please try again.");
       }
     } catch (err) {
-      toast.error(err?.response?.data?.message || "Signup failed. Please try again.");
+      toast.error(
+        err?.response?.data?.message || "Signup failed. Please try again.",
+      );
     }
   };
   return (


### PR DESCRIPTION
## Description
Fixed signup error handling in `Signup.jsx`. Previously, `navigate("/login")` was called unconditionally, so even on API failure the user was redirected and the error toast was empty. Wrapped the API call in try/catch and moved the redirect inside the success block.

## Closes Issue #28  

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews

Before: Empty toast + redirect to login on failure
After: Proper error toast shown, user stays on signup page

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [x] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced signup error handling and user feedback. Success messages now appear before redirecting to login, preventing unnecessary redirects on signup failures. Detailed server error messages are displayed when available, with a helpful fallback message for unexpected errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harsh-vardhan09/AthLead/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->