### PR TITLE
feat: add /me route for authenticated user validation fixes #30

### DIFF
--- a/Athlead-client/src/api/axios.js
+++ b/Athlead-client/src/api/axios.js
@@ -33,8 +33,10 @@ api.interceptors.response.use(
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return api(originalRequest);
       } catch (error) {
-        console.log(error);
+        localStorage.removeItem("accessToken");
+        return Promise.reject(error);
       }
     }
+    return Promise.reject(err);
   },
 );

--- a/Athlead-client/src/context/AppProvider.jsx
+++ b/Athlead-client/src/context/AppProvider.jsx
@@ -13,9 +13,7 @@ const AppProvider = ({ children }) => {
       return;
     }
     api
-      .get("/api/auth/me", {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .get("/api/auth/me")
       .then((res) => {
         if (res.data) setLoggedIn(true);
       })

--- a/Athlead-client/src/context/AppProvider.jsx
+++ b/Athlead-client/src/context/AppProvider.jsx
@@ -1,13 +1,33 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AppContext from "./AppContext";
+import { api } from "../api/axios";
 
 const AppProvider = ({ children }) => {
-  const [loggedIn, setLoggedIn] = useState(
-    !!localStorage.getItem("accessToken"),
-  );
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    api
+      .get("/api/auth/me", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        if (res.data) setLoggedIn(true);
+      })
+      .catch(() => {
+        localStorage.removeItem("accessToken");
+        setLoggedIn(false);
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
   return (
-    <AppContext.Provider value={{ loggedIn, setLoggedIn }}>
+    <AppContext.Provider value={{ loggedIn, setLoggedIn, loading }}>
       {children}
     </AppContext.Provider>
   );

--- a/Athlead-client/src/context/AppProvider.jsx
+++ b/Athlead-client/src/context/AppProvider.jsx
@@ -19,9 +19,11 @@ const AppProvider = ({ children }) => {
       .then((res) => {
         if (res.data) setLoggedIn(true);
       })
-      .catch(() => {
-        localStorage.removeItem("accessToken");
-        setLoggedIn(false);
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          localStorage.removeItem("accessToken");
+          setLoggedIn(false);
+        }
       })
       .finally(() => setLoading(false));
   }, []);

--- a/Athlead-client/src/context/IsLoggedIn.jsx
+++ b/Athlead-client/src/context/IsLoggedIn.jsx
@@ -1,13 +1,11 @@
 import { Navigate } from "react-router";
 import { useAuth } from "./useAuth";
-import { Children } from "react";
 
 const IsLoggedIn = ({ children }) => {
-  const { loggedIn } = useAuth();
+  const { loggedIn, loading } = useAuth();
 
-  if (loggedIn) {
-    return <Navigate to={"/dashboard"} replace />;
-  }
+  if (loading) return null;
+  if (loggedIn) return <Navigate to="/dashboard" replace />;
   return children;
 };
 

--- a/Athlead-client/src/context/ProtectedRoute.jsx
+++ b/Athlead-client/src/context/ProtectedRoute.jsx
@@ -1,13 +1,11 @@
 import { Navigate } from "react-router";
 import { useAuth } from "./useAuth";
-import { Children } from "react";
 
 const ProtectedRoute = ({ children }) => {
-  const { loggedIn } = useAuth();
+  const { loggedIn, loading } = useAuth();
 
-  if (!loggedIn) {
-    return <Navigate to={"/login"} replace />;
-  }
+  if (loading) return null;
+  if (!loggedIn) return <Navigate to="/login" replace />;
   return children;
 };
 

--- a/Backend/controllers/authController.js
+++ b/Backend/controllers/authController.js
@@ -137,7 +137,7 @@ export const refesh = async (req, res) => {
       accessToken: newAccessToken,
     });
   } catch (error) {
-    res.json({
+    res.status(401).json({
       success: false,
       message: error.message,
     });

--- a/Backend/controllers/authController.js
+++ b/Backend/controllers/authController.js
@@ -119,21 +119,31 @@ export const refesh = async (req, res) => {
   try {
     if (!token) {
       return res.status(401).json({
+        success: false,
         message: "token not present",
       });
     }
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     if (!decoded) {
       return res.status(401).json({
+        success: false,
         message: "invalid token",
       });
     }
     const user = await User.findOne({ _id: decoded.id });
     // console.log(user);
 
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: "User not found",
+      });
+    }
+
     const newAccessToken = user.generateAccessToken();
 
-    res.json({
+    res.status(200).json({
+      success: true,
       accessToken: newAccessToken,
     });
   } catch (error) {

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -3,7 +3,7 @@ import "dotenv/config";
 import cors from "cors";
 import { getNews } from "./controllers/newsController.js";
 import db from "./config/db.js";
-import { editUser, getUser, refesh } from "./controllers/authController.js";
+import { editUser, refesh } from "./controllers/authController.js";
 import passport from "passport";
 import cookieParser from "cookie-parser";
 import userRouter from "./routes/userRoutes.js";
@@ -74,11 +74,6 @@ app.patch(
   passport.authenticate("jwt", { session: false }),
   upload.single("profile_picture"),
   editUser,
-);
-app.get(
-  "/api/user/me",
-  passport.authenticate("jwt", { session: false }),
-  getUser,
 );
 app.get(
   "/api/score/rank",

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -3,7 +3,7 @@ import "dotenv/config";
 import cors from "cors";
 import { getNews } from "./controllers/newsController.js";
 import db from "./config/db.js";
-import { editUser, refesh } from "./controllers/authController.js";
+import { editUser, getUser, refesh } from "./controllers/authController.js";
 import passport from "passport";
 import cookieParser from "cookie-parser";
 import userRouter from "./routes/userRoutes.js";
@@ -74,6 +74,11 @@ app.patch(
   passport.authenticate("jwt", { session: false }),
   upload.single("profile_picture"),
   editUser,
+);
+app.get(
+  "/api/user/me",
+  passport.authenticate("jwt", { session: false }),
+  getUser,
 );
 app.get(
   "/api/score/rank",

--- a/Backend/routes/userRoutes.js
+++ b/Backend/routes/userRoutes.js
@@ -3,12 +3,15 @@ import {
   LoginAuth,
   logout,
   SingupAuth,
+  getUser,
 } from "../controllers/authController.js";
+import passport from "passport";
 
 const router = Router();
 
 router.post("/signup", SingupAuth);
 router.post("/login", LoginAuth);
 router.post("/logout", logout);
+router.get("/me", passport.authenticate("jwt", { session: false }), getUser);
 
 export default router;


### PR DESCRIPTION
## Description
Added a protected `GET /me` route that returns the currently authenticated user's profile based on a verified JWT token.

Fixes #30 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews

<-add images for visual if changes in UI->

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [ ] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated "current user" endpoint so the app can reliably fetch the signed-in user.

* **Bug Fixes**
  * Token refresh failures now sign users out (stored token removed) and surface authentication errors.
  * Refresh endpoint consistently returns 401 on failure with standardized error responses.

* **Refactor**
  * Client auth now initializes via an API check with a loading state; protected/guest routes wait for this check before redirecting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harsh-vardhan09/AthLead/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->