### PR TITLE
feat: auto refresh user data after profile edit closes #4

### DIFF
--- a/Athlead-client/src/Components/EditForm.jsx
+++ b/Athlead-client/src/Components/EditForm.jsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import { api } from "../api/axios";
 import toast from "react-hot-toast";
+import { useAuth } from "../context/useAuth";
 
 const EditForm = ({ setEditForm }) => {
   const {
@@ -13,12 +14,15 @@ const EditForm = ({ setEditForm }) => {
     formState: { errors },
   } = useForm();
   const navigate = useNavigate();
+  const { setUser } = useAuth();
 
   const profile = watch("profile_picture");
 
   const onSubmit = async (data) => {
     const formData = new FormData();
-    formData.append("profile_picture", data.profile_picture[0]);
+    if (data.profile_picture && data.profile_picture[0]) {
+      formData.append("profile_picture", data.profile_picture[0]);
+    }
     formData.append("fullname", data.fullname);
     formData.append("phone", data.phone);
     formData.append("address", data.address);
@@ -28,7 +32,14 @@ const EditForm = ({ setEditForm }) => {
     console.log(res);
 
     if (res.data.success) {
+      try {
+        const updated = await api.get("/api/auth/me");
+        setUser(updated.data.user);
+      } catch {
+        // /me failed but edit succeeded, continue
+      }
       toast.success(res.data.message);
+      setEditForm(false);
       navigate("/dashboard");
     } else {
       toast.error(res.data.message);
@@ -92,9 +103,8 @@ const EditForm = ({ setEditForm }) => {
                 required: true,
                 maxLength: { value: 20, message: "Must be < 20 letters" },
               })}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${
-                errors.fullname ? "border-red-500/80" : "border-white/12"
-              }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.fullname ? "border-red-500/80" : "border-white/12"
+                }`}
             />
             {errors.fullname && (
               <p className="text-xs text-red-400 mt-1">
@@ -115,9 +125,8 @@ const EditForm = ({ setEditForm }) => {
                   type="number"
                   placeholder="98765 43210"
                   {...register("phone", { required: true })}
-                  className={`flex-1 max-w-full bg-white/7 border rounded-xl px-3 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${
-                    errors.phone ? "border-red-500/80" : "border-white/12"
-                  }`}
+                  className={`flex-1 max-w-full bg-white/7 border rounded-xl px-3 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.phone ? "border-red-500/80" : "border-white/12"
+                    }`}
                 />
               </div>
             </div>
@@ -130,9 +139,8 @@ const EditForm = ({ setEditForm }) => {
             <input
               type="date"
               {...register("DOB", { required: true })}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${
-                errors.DOB ? "border-red-500/80" : "border-white/12"
-              }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.DOB ? "border-red-500/80" : "border-white/12"
+                }`}
             />
             {errors.DOB && (
               <p className="text-xs text-red-400 mt-1">{errors.DOB.message}</p>
@@ -149,9 +157,8 @@ const EditForm = ({ setEditForm }) => {
             <input
               type="text"
               {...register("address")}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${
-                errors.DOB ? "border-red-500/80" : "border-white/12"
-              }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.address ? "border-red-500/80" : "border-white/12"
+                }`}
             />
           </div>
           <div>

--- a/Athlead-client/src/context/AppProvider.jsx
+++ b/Athlead-client/src/context/AppProvider.jsx
@@ -1,33 +1,45 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import AppContext from "./AppContext";
 import { api } from "../api/axios";
 
 const AppProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState(null);
 
-  useEffect(() => {
+  const fetchUser = useCallback(async () => {
     const token = localStorage.getItem("accessToken");
     if (!token) {
+      setLoggedIn(false);
+      setUser(null);
       setLoading(false);
       return;
     }
-    api
-      .get("/api/auth/me")
-      .then((res) => {
-        if (res.data) setLoggedIn(true);
-      })
-      .catch((err) => {
-        if (err.response?.status === 401) {
-          localStorage.removeItem("accessToken");
-          setLoggedIn(false);
-        }
-      })
-      .finally(() => setLoading(false));
+    try {
+      const res = await api.get("/api/auth/me");
+      if (res.data) {
+        setLoggedIn(true);
+        setUser(res.data.user);
+      }
+    } catch (err) {
+      if (err.response?.status === 401) {
+        localStorage.removeItem("accessToken");
+        setLoggedIn(false);
+        setUser(null);
+      }
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
   return (
-    <AppContext.Provider value={{ loggedIn, setLoggedIn, loading }}>
+    <AppContext.Provider
+      value={{ loggedIn, setLoggedIn, loading, user, setUser, fetchUser }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -25,6 +25,7 @@ import {
 import { useNavigate } from "react-router";
 import { useEffect } from "react";
 import { api } from "../api/axios";
+import { useAuth } from "../context/useAuth";
 import dayjs from "dayjs";
 import EditForm from "../Components/EditForm";
 
@@ -32,9 +33,14 @@ const Dashboard = () => {
   const [scores, setScores] = useState([]);
   const navigate = useNavigate();
   const [editForm, setEditForm] = useState(false);
-  const [user, setUser] = useState({});
+  const { user, loading, fetchUser } = useAuth();
   const [rank, setRank] = useState([]);
   useEffect(() => {
+    fetchUser();
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
     const getScore = async () => {
       const scores = await api.get("/api/my-scores");
       const formattedScores = scores.data.scores.map((item) => ({
@@ -46,20 +52,14 @@ const Dashboard = () => {
     };
     getScore();
 
-    const getUser = async () => {
-      const resUser = await api.get("/api/user/me");
-      setUser(resUser.data.user);
-      // console.log(resUser);
-    };
-    getUser();
-
     const getRank = async () => {
       const res = await api.get("/api/score/rank");
       setRank(res.data.rank);
-      // console.log(res.data.rank);
     };
     getRank();
-  }, []);
+  }, [user]);
+
+  if (loading) return null;
 
   return (
     <section className="dark-bg relative max-w-screen min-h-screen flex flex-col items-start justify-center">
@@ -67,22 +67,22 @@ const Dashboard = () => {
         <div className=" flex items-center justify-around gap-3 max-w-full bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-2xl shadow-xl">
           <div className="flex gap-3">
             <img
-              src={user.image}
+              src={user?.image}
               alt=""
               className="w-25 h-25 rounded-full p-2"
             />
 
             <div className="flex flex-col items-start justify-center">
               <h1 className="font-semibold font-segoe text-xl ">
-                {user.fullname}
+                {user?.fullname}
               </h1>
               <div className="flex  text-md basic gap-3">
                 <p className="flex items-center">
-                  <MapPin className="h-4 w-4 mr-1" /> {user.state}
+                  <MapPin className="h-4 w-4 mr-1" /> {user?.state}
                 </p>
                 <p className="flex items-center ">
                   <Calendar className="h-4 w-4 mr-1" />
-                  {dayjs(user.DOB).format("DD MMM ")}
+                  {dayjs(user?.DOB).format("DD MMM ")}
                 </p>
               </div>
             </div>

--- a/Backend/controllers/authController.js
+++ b/Backend/controllers/authController.js
@@ -4,6 +4,7 @@ import { LoginVal, signupVal } from "../utils/zodValidation.js";
 import { User } from "../models/Users.js";
 import { v2 as cloudinary } from "cloudinary";
 import { normalizeEmail } from "../utils/normalizeEmail.js";
+import fs from "fs";
 
 cloudinary.config({
   cloud_name: process.env.CLOUD_NAME,
@@ -163,13 +164,18 @@ export const logout = (req, res) => {
 };
 
 export const editUser = async (req, res) => {
-  const profilePicture = req.file.path;
   const { fullname, phone, address, DOB } = req.body;
-  // console.log(req.user._id);
-  // console.log(DOB);
 
   try {
-    const profileUrl = await cloudinary.uploader.upload(profilePicture);
+    let imageUrl;
+
+    if (req.file) {
+      const profileUrl = await cloudinary.uploader.upload(req.file.path);
+      imageUrl = profileUrl.url;
+      fs.unlink(req.file.path, (err) => {
+        if (err) console.error("Failed to delete temp file:", err);
+      });
+    }
 
     await User.findByIdAndUpdate(
       req.user._id,
@@ -177,13 +183,11 @@ export const editUser = async (req, res) => {
         fullname,
         phone,
         state: address,
-        DOB: DOB,
-        image: profileUrl.url,
+        DOB,
+        ...(imageUrl && { image: imageUrl }),
       },
       { returnDocument: "after" },
     );
-
-    // console.log(user);
 
     res.json({
       success: true,
@@ -191,7 +195,7 @@ export const editUser = async (req, res) => {
     });
   } catch (error) {
     console.log(error);
-    res.json({
+    res.status(500).json({
       success: false,
       message: error.message,
     });

--- a/Backend/routes/userRoutes.js
+++ b/Backend/routes/userRoutes.js
@@ -4,14 +4,35 @@ import {
   logout,
   SingupAuth,
   getUser,
+  editUser,
+  refesh,
 } from "../controllers/authController.js";
 import passport from "passport";
+import multer from "multer";
 
+const upload = multer({
+  dest: "uploads/",
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith("image/")) {
+      cb(null, true);
+    } else {
+      cb(new Error("Only image files are allowed"), false);
+    }
+  },
+});
 const router = Router();
 
 router.post("/signup", SingupAuth);
 router.post("/login", LoginAuth);
 router.post("/logout", logout);
+router.post("/refresh", refesh);
 router.get("/me", passport.authenticate("jwt", { session: false }), getUser);
+router.patch(
+  "/edit",
+  passport.authenticate("jwt", { session: false }),
+  upload.single("profile_picture"),
+  editUser,
+);
 
 export default router;


### PR DESCRIPTION
## Description
Auto-refreshes user data after profile edit without page reload.

- Added `user`/`setUser` to AppContext
- AppProvider refetches `/me` on `loggedIn` change
- EditForm refetches `/me` on success and updates global state
- Dashboard uses context `user` instead of local state
- Added null check for `req.file` in editUser

Closes #4 


## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews

<-add images for visual if changes in UI->

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [ ] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile editing now supports optional image upload with client/server validation and improved upload handling.
  * App-wide auth state exposes and refreshes user data so profile changes propagate immediately.

* **Bug Fixes**
  * Dashboard reliably displays updated profile info and waits for auth loading.
  * Edit flow shows success feedback, closes the editor (no unwanted navigation), and corrects input error highlighting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harsh-vardhan09/AthLead/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->