### PR TITLE
fix: restrict leaderboard to top 5

### DIFF
--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -36,10 +36,6 @@ const Dashboard = () => {
   const { user, loading, fetchUser } = useAuth();
   const [rank, setRank] = useState([]);
   useEffect(() => {
-    fetchUser();
-  }, []);
-
-  useEffect(() => {
     const initDashboard = async () => {
       let currentUser = user;
       if (!currentUser) {

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -61,6 +61,24 @@ const Dashboard = () => {
 
   if (loading) return null;
 
+const getDisplayRankings = () => {
+  const topFive = rank.slice(0, 5);
+
+  const isMeInTopFive = topFive.some((p) => p.isMe);
+
+  if (isMeInTopFive || rank.length <= 5) {
+    return topFive;
+  }
+
+  const myData = rank.find((p) => p.isMe);
+
+  if (myData) {
+    return [...topFive, myData];
+  }
+
+  return topFive;
+};
+
   return (
     <section className="dark-bg relative max-w-screen min-h-screen flex flex-col items-start justify-center">
       <div className="grid grid-cols-1 md:grid-cols-2  mt-10 w-full gap-5 p-10">
@@ -119,9 +137,9 @@ const Dashboard = () => {
               </tr>
             </thead>
             <tbody>
-              {rank.map((p, i) => (
+              {getDisplayRankings().map((p, i) => (
                 <tr
-                  key={p}
+                  key={p.user?._id|| `athlete-${i}`}
                   className={`border-b basic border-white/3 transition-colors ${p.isMe ? "bg-teal-500/3" : "hover:bg-white/2"}`}
                 >
                   <td className="flex items-center justify-center">

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -40,45 +40,54 @@ const Dashboard = () => {
   }, []);
 
   useEffect(() => {
-    if (!user) return;
-    const getScore = async () => {
-      const scores = await api.get("/api/my-scores");
-      const formattedScores = scores.data.scores.map((item) => ({
-        ...item,
-        date: dayjs(item.date).format("DD MMM YY"),
-      }));
-      setScores(formattedScores);
-      console.log(scores);
-    };
-    getScore();
+    const initDashboard = async () => {
+      let currentUser = user;
+      if (!currentUser) {
+        currentUser = await fetchUser();
+      }
 
-    const getRank = async () => {
-      const res = await api.get("/api/score/rank");
-      setRank(res.data.rank);
+      if (currentUser) {
+        try {
+          const scoresRes = await api.get("/api/my-scores");
+          const formattedScores = scoresRes.data.scores.map((item) => ({
+            ...item,
+            date: dayjs(item.date).format("DD MMM YY"),
+          }));
+          setScores(formattedScores);
+
+          const rankRes = await api.get("/api/score/rank");
+          const rankWithIsMe = rankRes.data.rank.map((item, index) => ({
+            ...item,
+            originalRank: index + 1, 
+            isMe: item.user?._id === currentUser?._id || item.isMe, 
+          }));
+          setRank(rankWithIsMe);
+        } catch (error) {
+          console.error("Error loading dashboard data:", error);
+        }
+      }
     };
-    getRank();
-  }, [user]);
+
+    initDashboard();
+  }, [user, fetchUser]); 
 
   if (loading) return null;
 
 const getDisplayRankings = () => {
-  const topFive = rank.slice(0, 5);
+    const topFive = rank.slice(0, 5);
+    const isMeInTopFive = topFive.some((p) => p.isMe);
 
-  const isMeInTopFive = topFive.some((p) => p.isMe);
+    if (isMeInTopFive || rank.length <= 5) {
+      return topFive;
+    }
 
-  if (isMeInTopFive || rank.length <= 5) {
+    const myData = rank.find((p) => p.isMe);
+    if (myData) {
+      return [...topFive, myData];
+    }
+
     return topFive;
-  }
-
-  const myData = rank.find((p) => p.isMe);
-
-  if (myData) {
-    return [...topFive, myData];
-  }
-
-  return topFive;
-};
-
+  };
   return (
     <section className="dark-bg relative max-w-screen min-h-screen flex flex-col items-start justify-center">
       <div className="grid grid-cols-1 md:grid-cols-2  mt-10 w-full gap-5 p-10">
@@ -139,29 +148,34 @@ const getDisplayRankings = () => {
             <tbody>
               {getDisplayRankings().map((p, i) => (
                 <tr
-                  key={p.user?._id|| `athlete-${i}`}
+                  key={p.user?._id || `athlete-${i}`}
                   className={`border-b basic border-white/3 transition-colors ${p.isMe ? "bg-teal-500/3" : "hover:bg-white/2"}`}
                 >
                   <td className="flex items-center justify-center">
-                    {i <= 3 ? (
+                    {/* Render visual styling based on true original rank instead of loop index */}
+                    {p.originalRank && p.originalRank <= 4 ? (
                       <div
-                        className={`w-5 h-5 rounded-full flex items-center justify-center  text-[10px] font-black ${i === 1 ? "bg-amber-400/15 text-amber-400" : i ? "bg-slate-400/15 text-slate-400" : "bg-orange-800/15 text-orange-700"}`}
+                        className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-black ${
+                          p.originalRank === 2 ? "bg-amber-400/15 text-amber-400" : 
+                          p.originalRank === 3 ? "bg-slate-400/15 text-slate-400" : 
+                          p.originalRank === 1 ? "bg-orange-800/15 text-orange-700" : "bg-slate-400/15 text-slate-400"
+                        }`}
                       >
-                        {i + 1}
+                        {p.originalRank}
                       </div>
                     ) : (
                       <span className="text-[11px] w-5 h-5 text-slate-600 pl-1">
-                        {i + 1}
+                        {p.originalRank || "-"}
                       </span>
                     )}
                   </td>
                   <td
                     className={`mr-3 text-[13px] font-medium ${p.isMe ? "text-teal-300" : "text-slate-200"}`}
                   >
-                    {p.user.fullname}{" "}
+                    {p.user?.fullname}{" "}
                   </td>
                   <td className="text-sm pl-1">cycling</td>
-                  <td className="text-sm">{p.user.state}</td>
+                  <td className="text-sm">{p.user?.state}</td>
                   <td>{p.score}</td>
                   <td className="text-center">{p.trend}</td>
                 </tr>


### PR DESCRIPTION
## Description
Refactored the dashboard leaderboard logic to limit the default display list to the top 5 athletes. If the logged-in user falls outside of the top 5 positions, their ranking data is dynamically found and appended to the bottom of the table as a pinned entry. 

Additionally updated the React list iteration layout to use crash-safe optional chaining (`p.user?._id`) and a fallback mapping strategy to prevent runtime crashes from unpopulated database records or missing key attributes.

## Closes Issue #9 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews
## Checklist

- [x] I tested my changes
- [ ] I ran npm run lint
- [ ] I ran npm run build
- [ ] I ran npm run format
- [ ] ] I updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Leaderboard now always shows your ranking even when you’re outside the top positions.
  * More reliable row rendering to reduce display glitches.

* **Enhancements**
  * Top rankings display correct rank numbers and clearer athlete name/state info.
  * Rankings list shows top five plus your entry when applicable for better context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harsh-vardhan09/AthLead/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->