### PR TITLE
feat: addition of old dp as visual guide for changing DP in the edit form #25

### DIFF
--- a/Athlead-client/src/Components/EditForm.jsx
+++ b/Athlead-client/src/Components/EditForm.jsx
@@ -14,7 +14,7 @@ const EditForm = ({ setEditForm }) => {
     formState: { errors },
   } = useForm();
   const navigate = useNavigate();
-  const { setUser } = useAuth();
+  const { setUser, user } = useAuth();
 
   const profile = watch("profile_picture");
 
@@ -69,7 +69,7 @@ const EditForm = ({ setEditForm }) => {
               >
                 <PlusCircle
                   size={50}
-                  className={`${profile ? "hidden" : ""}`}
+                  className={`${(profile && profile[0]) || user?.image ? "hidden" : ""}`}
                 />
                 <input
                   id="profile_picture"
@@ -83,7 +83,7 @@ const EditForm = ({ setEditForm }) => {
                   src={
                     profile && profile[0]
                       ? URL.createObjectURL(profile[0])
-                      : "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQw3k1c6JaNUexk2h38jFUHu4j3O73P8mgVkw&s"
+                      : user?.image || null
                   }
                   alt=""
                   className=" w-30 h-30 rounded-full object-cover mt-2"
@@ -103,8 +103,9 @@ const EditForm = ({ setEditForm }) => {
                 required: true,
                 maxLength: { value: 20, message: "Must be < 20 letters" },
               })}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.fullname ? "border-red-500/80" : "border-white/12"
-                }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${
+                errors.fullname ? "border-red-500/80" : "border-white/12"
+              }`}
             />
             {errors.fullname && (
               <p className="text-xs text-red-400 mt-1">
@@ -125,8 +126,9 @@ const EditForm = ({ setEditForm }) => {
                   type="number"
                   placeholder="98765 43210"
                   {...register("phone", { required: true })}
-                  className={`flex-1 max-w-full bg-white/7 border rounded-xl px-3 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.phone ? "border-red-500/80" : "border-white/12"
-                    }`}
+                  className={`flex-1 max-w-full bg-white/7 border rounded-xl px-3 py-2.5 text-sm text-white placeholder:text-white/25 outline-none focus:bg-[#1d9e75]/8 transition-all ${
+                    errors.phone ? "border-red-500/80" : "border-white/12"
+                  }`}
                 />
               </div>
             </div>
@@ -139,8 +141,9 @@ const EditForm = ({ setEditForm }) => {
             <input
               type="date"
               {...register("DOB", { required: true })}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.DOB ? "border-red-500/80" : "border-white/12"
-                }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${
+                errors.DOB ? "border-red-500/80" : "border-white/12"
+              }`}
             />
             {errors.DOB && (
               <p className="text-xs text-red-400 mt-1">{errors.DOB.message}</p>
@@ -157,8 +160,9 @@ const EditForm = ({ setEditForm }) => {
             <input
               type="text"
               {...register("address")}
-              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${errors.address ? "border-red-500/80" : "border-white/12"
-                }`}
+              className={`w-full bg-white/7 border rounded-xl px-3.5 py-2.5 text-sm text-white outline-none focus:bg-[#1d9e75]/8 transition-all ${
+                errors.address ? "border-red-500/80" : "border-white/12"
+              }`}
             />
           </div>
           <div>


### PR DESCRIPTION
## Description
- Fetch existing user DP from auth context
- Display current profile picture as default preview
- Show placeholder only when no DP exists
- Instant preview on new image selection

Closes #25 


## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews

<img width="1440" height="716" alt="Screenshot 2026-05-30 at 7 59 44 PM" src="https://github.com/user-attachments/assets/6dd29998-289a-433d-94fb-024c725ac49c" />

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [ ] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile image preview to better display newly selected images while falling back to existing profile image.
  * Enhanced form validation feedback with conditional error state styling on input fields.

* **Style**
  * Updated form input styling for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harsh-vardhan09/AthLead/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->