### PR TITLE
feat(auth): add OTP email verification with UUID session flow

### DIFF
--- a/Athlead-client/src/Components/OtpVerification.jsx
+++ b/Athlead-client/src/Components/OtpVerification.jsx
@@ -1,0 +1,248 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { api } from "../api/axios";
+import toast from "react-hot-toast";
+
+// localStorage key where the OTP session UUID is stored
+export const OTP_SESSION_KEY = "athlead_otp_session";
+
+/**
+ * OtpVerification
+ *
+ * Props:
+ *   maskedEmail  {string}    - display-only masked email e.g. "j***@gmail.com"
+ *   onVerified   {function}  - called with no args when OTP is confirmed
+ *   onBack       {function}  - called when user clicks "← Back"
+ *
+ * Reads  sessionId from localStorage[OTP_SESSION_KEY] — set by Signup.jsx after send-otp.
+ * Never sends email to the backend — all calls use sessionId only.
+ */
+const OtpVerification = ({ maskedEmail, onVerified, onBack }) => {
+  const [otpDigits,     setOtpDigits]     = useState(Array(6).fill(""));
+  const [loading,       setLoading]       = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [cooldown,      setCooldown]      = useState(60); // seconds until resend is allowed
+  const inputRefs = useRef([]);
+
+  // ── Countdown timer ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const t = setTimeout(() => setCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldown]);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  const getSessionId = () => localStorage.getItem(OTP_SESSION_KEY);
+
+  const clearDigits = () => {
+    setOtpDigits(Array(6).fill(""));
+    setTimeout(() => inputRefs.current[0]?.focus(), 0);
+  };
+
+  // ── Input handlers ─────────────────────────────────────────────────────────
+  const handleChange = (index, value) => {
+    if (!/^\d*$/.test(value)) return;
+    const next = [...otpDigits];
+    next[index] = value.slice(-1);
+    setOtpDigits(next);
+    if (value && index < 5) inputRefs.current[index + 1]?.focus();
+  };
+
+  const handleKeyDown = (index, e) => {
+    if (e.key === "Backspace" && !otpDigits[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e) => {
+    const digits = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, 6);
+    if (!digits) return;
+    const next = Array(6).fill("");
+    digits.split("").forEach((ch, i) => { next[i] = ch; });
+    setOtpDigits(next);
+    inputRefs.current[Math.min(digits.length, 5)]?.focus();
+    e.preventDefault();
+  };
+
+  // ── Verify ─────────────────────────────────────────────────────────────────
+  const handleVerify = async () => {
+    const otp       = otpDigits.join("");
+    const sessionId = getSessionId();
+
+    if (otp.length < 6) {
+      toast.error("Please enter the complete 6-digit OTP");
+      return;
+    }
+    if (!sessionId) {
+      toast.error("Session expired. Please go back and try again.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await api.post("/api/auth/verify-otp", { sessionId, otp });
+
+      if (res.data.success) {
+        toast.success("Email verified!");
+        onVerified();
+      } else {
+        toast.error(res.data.message || "Invalid OTP");
+        clearDigits();
+
+        // If the session was killed (expired / locked), send user back
+        if (res.data.expired || res.data.locked) {
+          localStorage.removeItem(OTP_SESSION_KEY);
+          setTimeout(onBack, 1500);
+        }
+      }
+    } catch (err) {
+      const data = err?.response?.data ?? {};
+      toast.error(data.message || "Verification failed");
+      clearDigits();
+      if (data.expired || data.locked) {
+        localStorage.removeItem(OTP_SESSION_KEY);
+        setTimeout(onBack, 1500);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ── Resend ─────────────────────────────────────────────────────────────────
+  const handleResend = useCallback(async () => {
+    if (cooldown > 0 || resendLoading) return;
+
+    const sessionId = getSessionId();
+    if (!sessionId) {
+      toast.error("Session expired. Please go back and start over.");
+      return;
+    }
+
+    setResendLoading(true);
+    try {
+      const res = await api.post("/api/auth/resend-otp", { sessionId });
+
+      if (res.data.success) {
+        toast.success("New OTP sent to your email!");
+        setCooldown(60);
+        clearDigits();
+      } else {
+        toast.error(res.data.message || "Could not resend OTP");
+      }
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Could not resend OTP");
+    } finally {
+      setResendLoading(false);
+    }
+  }, [cooldown, resendLoading]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  const allFilled = otpDigits.every(Boolean);
+
+  return (
+    <div className="flex flex-col items-center gap-6 px-5 py-8 w-full">
+
+      {/* Header */}
+      <div className="text-center">
+        <h3 className="text-white font-akkurat text-2xl font-extrabold">
+          Verify Your Email
+        </h3>
+        <p className="text-sm text-white/50 mt-2 max-w-xs leading-relaxed">
+          We sent a 6-digit code to{" "}
+          <span className="text-teal-400 font-semibold">{maskedEmail}</span>.
+          <br />
+          It expires in <span className="text-white/70">5 minutes</span>.
+        </p>
+      </div>
+
+      {/* OTP digit inputs */}
+      <div className="flex gap-3" onPaste={handlePaste}>
+        {otpDigits.map((digit, i) => (
+          <input
+            key={i}
+            ref={(el) => (inputRefs.current[i] = el)}
+            type="text"
+            inputMode="numeric"
+            maxLength={1}
+            value={digit}
+            autoFocus={i === 0}
+            onChange={(e) => handleChange(i, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(i, e)}
+            className={[
+              "w-11 h-13 text-center text-xl font-bold text-white rounded-xl border",
+              "bg-white/5 focus:outline-none transition-all duration-150",
+              digit
+                ? "border-teal-400 bg-teal-400/10"
+                : "border-white/20",
+              "focus:border-teal-400 focus:bg-teal-400/10",
+            ].join(" ")}
+          />
+        ))}
+      </div>
+
+      {/* Verify button */}
+      <button
+        onClick={handleVerify}
+        disabled={loading || !allFilled}
+        className="w-full border border-white/20 rounded-md h-9
+          bg-linear-to-r from-teal-400 via-teal-800 to-blue-400
+          cursor-pointer hover:from-teal-600 hover:to-blue-800
+          hover:scale-105 transition-all hover:duration-200
+          disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100
+          text-white font-medium text-sm"
+      >
+        {loading ? (
+          <span className="flex items-center justify-center gap-2">
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            Verifying…
+          </span>
+        ) : (
+          "Verify OTP"
+        )}
+      </button>
+
+      {/* Resend row */}
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-sm text-white/40">
+          Didn&apos;t receive it?{" "}
+          <button
+            onClick={handleResend}
+            disabled={cooldown > 0 || resendLoading}
+            className={[
+              "font-medium transition-colors",
+              cooldown > 0 || resendLoading
+                ? "text-white/25 cursor-not-allowed"
+                : "text-teal-400 cursor-pointer hover:text-teal-300 underline underline-offset-2",
+            ].join(" ")}
+          >
+            {resendLoading
+              ? "Sending…"
+              : cooldown > 0
+              ? `Resend in ${cooldown}s`
+              : "Resend OTP"}
+          </button>
+        </p>
+        {cooldown > 0 && (
+          <div className="w-40 h-0.5 bg-white/10 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-teal-400/60 transition-all duration-1000"
+              style={{ width: `${((60 - cooldown) / 60) * 100}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Back link */}
+      <button
+        onClick={() => {
+          localStorage.removeItem(OTP_SESSION_KEY);
+          onBack();
+        }}
+        className="text-xs text-white/30 hover:text-white/60 transition-colors cursor-pointer mt-1"
+      >
+        ← Back to signup
+      </button>
+    </div>
+  );
+};
+
+export default OtpVerification;

--- a/Athlead-client/src/pages/Signup.jsx
+++ b/Athlead-client/src/pages/Signup.jsx
@@ -5,221 +5,315 @@ import { useNavigate } from "react-router";
 import toast, { Toaster } from "react-hot-toast";
 import { api } from "../api/axios";
 import CalendarPicker from "../Components/CalendarPicker";
+import OtpVerification, { OTP_SESSION_KEY } from "../Components/OtpVerification.jsx";
 
+// ── Step constants ────────────────────────────────────────────────────────────
+const STEP_FORM       = "form";
+const STEP_OTP        = "otp";
+const STEP_SUBMITTING = "submitting";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+/** Masks "john.doe@gmail.com" → "j***@gmail.com" for display-only privacy. */
+const maskEmail = (email) => {
+  const [local, domain] = email.split("@");
+  return `${local[0]}***@${domain}`;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 const Signup = () => {
   const {
     register,
     handleSubmit,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm();
-  const [show, setShow] = useState(false);
+
+  const [show,          setShow]          = useState(false);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+  const [step,          setStep]          = useState(STEP_FORM);
+  const [maskedEmail,   setMaskedEmail]   = useState(""); // display only
+  const [sendingOtp,    setSendingOtp]    = useState(false);
 
   const navigate = useNavigate();
 
-  const onSubmit = async (data) => {
+  // ── Step 1: submit form → call send-otp → save sessionId → show OTP screen ──
+  const onSubmitForm = async (data) => {
+    setSendingOtp(true);
+    try {
+      console.log("BASE URL:", import.meta.env.VITE_BASE_URL);
+      const res = await api.post("/api/auth/send-otp", { email: data.email });
+
+      if (res.data.success) {
+        // Store the UUID in localStorage — OtpVerification reads it from there.
+        // We never put email in localStorage; the UUID maps to email server-side.
+        localStorage.setItem(OTP_SESSION_KEY, res.data.sessionId);
+        setMaskedEmail(maskEmail(data.email));
+        toast.success("OTP sent to your email!");
+        setStep(STEP_OTP);
+      } else {
+        toast.error(res.data.message || "Could not send OTP");
+      }
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Could not send OTP");
+    } finally {
+      setSendingOtp(false);
+    }
+  };
+
+  // ── Step 2: OTP verified → POST signup with sessionId (no email in body) ────
+  const onOtpVerified = async () => {
+    const data = getValues();
+
+    // Format DOB from DD/MM/YYYY → YYYY-MM-DD for the backend
     const formattedData = { ...data };
     if (data.DOB) {
       const [day, month, year] = data.DOB.split("/");
       formattedData.DOB = `${year}-${month}-${day}`;
     }
 
+    // Remove email from the payload — the backend reads it from the OTP session.
+    // This prevents a client-side email substitution after verification.
+    delete formattedData.email;
+
+    const sessionId = localStorage.getItem(OTP_SESSION_KEY);
+    if (!sessionId) {
+      toast.error("Session lost. Please start over.");
+      setStep(STEP_FORM);
+      return;
+    }
+
+    setStep(STEP_SUBMITTING);
     try {
-      const res = await api.post("/api/auth/signup", formattedData);
+      const res = await api.post("/api/auth/signup", {
+        ...formattedData,
+        sessionId,          // backend looks up email via this UUID
+      });
 
       if (res.data.success) {
+        localStorage.removeItem(OTP_SESSION_KEY); // clean up
         toast.success(res.data.message);
         navigate("/login");
       } else {
         toast.error(res.data.message || "Signup failed. Please try again.");
+        setStep(STEP_OTP);
       }
     } catch (err) {
-      toast.error(
-        err?.response?.data?.message || "Signup failed. Please try again.",
-      );
+      toast.error(err?.response?.data?.message || "Signup failed. Please try again.");
+      setStep(STEP_OTP);
     }
   };
+
+  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <section className="dark-bg relative max-w-screen min-h-screen flex items-center justify-center bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[60px_60px] bg-repeat overflow-hidden">
-      <div className=" h-2/3 max-w-96 w-full  bg-[#08325b]/30 border border-[#47a2bf]/60 text-start text-white rounded-xl">
-        <div className="px-5">
-          <h3 className="text-white font-akkurat text-2xl font-extrabold pt-5  ">
-            Create Account
-          </h3>
-          <p className="basic text-sm pt-2">
-            Already Registered?{" "}
-            <span
-              className=" text-lg bg-linear-to-r from-teal-400 to-blue-200 bg-clip-text text-transparent cursor-pointer"
-              onClick={() => navigate("/login")}
-            >
-              Sign In
-            </span>
-          </p>
-        </div>
-        <form
-          onSubmit={handleSubmit(onSubmit)}
-          className="flex flex-col gap-3 p-8"
-        >
-          <div className="w-full">
-            <label className="label">Full Name</label>
-            <input
-              type="text"
-              placeholder="John Doe..."
-              {...register("fullname", {
-                required: true,
-                maxLength: { value: 20, message: "Must be < 20 letters" },
-              })}
-              className={`input mb-4 ${errors.fullname ? "border-red-500/80" : "border-white/30"}`}
-            />
-            {errors.fullname && (
-              <p className="text-sm text-red-700">{errors.fullname.message}</p>
-            )}
-          </div>
+      <Toaster />
+      <div className="h-2/3 max-w-96 w-full bg-[#08325b]/30 border border-[#47a2bf]/60 text-start text-white rounded-xl">
 
-          <div>
-            <label className="label">Email</label>
-            <input
-              type="email"
-              placeholder="XXX@ABC.com"
-              {...register("email", {
-                required: true,
-                pattern: {
-                  value: /^[a-zA-Z0-9._%+-]+[@][a-zA-Z0-9.-]+[.][a-zA-Z]{2,}$/,
-                  message: "Wrong email format",
-                },
-              })}
-              className={`input mb-4 ${errors.email ? "border-red-500/80" : "border-white/30"}`}
-            />
-            {errors.email && (
-              <p className="text-sm text-red-700">{errors.email.message}</p>
-            )}
-          </div>
+        {/* ── OTP screen (shown during otp + submitting steps) ──── */}
+        {(step === STEP_OTP || step === STEP_SUBMITTING) && (
+          <OtpVerification
+            maskedEmail={maskedEmail}
+            onVerified={onOtpVerified}
+            onBack={() => {
+              localStorage.removeItem(OTP_SESSION_KEY);
+              setStep(STEP_FORM);
+            }}
+          />
+        )}
 
-          <div>
-            <label className="label">Phone</label>
-            <input
-              type="number"
-              placeholder="+91 XXX XXX"
-              {...register("phone")}
-              className={`input mb-4 ${errors.phone ? "border-red-500/80" : "border-white/30"}`}
-            />
-          </div>
-          <div className="w-full relative">
-            <label className="label">Date of Birth</label>
-            <div className="relative">
-              <input
-                type="text"
-                placeholder="DD/MM/YYYY"
-                {...register("DOB", {
-                  required: "Date of Birth is Required",
-                  pattern: {
-                    value: /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/,
-                    message: "Use DD/MM/YYYY Format",
-                  },
-                  validate: {
-                    notFuture: (value) => {
-                      const [day, month, year] = value.split("/").map(Number);
-                      const dob = new Date(year, month - 1, day);
-                      const minDate = new Date();
-                      minDate.setHours(0, 0, 0, 0);
-                      // Future DOB Vaidation - Setting Mininmun Age Limit
-                      // minDate.setFullYear(minDate.getFullYear() - 5) // For 5 Years and Older
-                      return (
-                        dob < minDate ||
-                        "Date of Birth should not today or later"
-                      ); // Change based on Min Age
-                    },
-                  },
-                })}
-                className={`input mb-4 pr-10 ${errors.DOB ? "border-red-500/80" : "border-white/30"}`}
-                readOnly
-              />
-              <Calendar
-                className="absolute right-3 top-1/2 -translate-y-1/2 h-full cursor-pointer hover:text-[#5dcaa5] transition-colors"
-                onClick={() => setIsCalendarOpen(!isCalendarOpen)}
-              />
-              {isCalendarOpen && (
-                <CalendarPicker
-                  selectedDate={watch("DOB")}
-                  onSelect={(formatted) => {
-                    setValue("DOB", formatted);
-                  }}
-                  onClose={() => setIsCalendarOpen(false)}
-                />
-              )}
+        {/* ── Signup form ───────────────────────────────────────── */}
+        {step === STEP_FORM && (
+          <>
+            <div className="px-5">
+              <h3 className="text-white font-akkurat text-2xl font-extrabold pt-5">
+                Create Account
+              </h3>
+              <p className="basic text-sm pt-2">
+                Already Registered?{" "}
+                <span
+                  className="text-lg bg-linear-to-r from-teal-400 to-blue-200 bg-clip-text text-transparent cursor-pointer"
+                  onClick={() => navigate("/login")}
+                >
+                  Sign In
+                </span>
+              </p>
             </div>
-            {errors.DOB && (
-              <p className="text-sm text-red-700">{errors.DOB.message}</p>
-            )}
-          </div>
 
-          <div>
-            <div className="flex gap-2.5">
-              {["male", "female"].map((g) => (
-                <label
-                  key={g}
-                  className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl border border-white/12 bg-white/5 text-sm text-white/50 cursor-pointer has-checked:border-[#1d9e75] has-checked:bg-[#1d9e75]/15 has-checked:text-[#5dcaa5] has-checked:font-medium transition-all"
+            <form
+              onSubmit={handleSubmit(onSubmitForm)}
+              className="flex flex-col gap-3 p-8"
+            >
+              {/* Full Name */}
+              <div className="w-full">
+                <label className="label">Full Name</label>
+                <input
+                  type="text"
+                  placeholder="John Doe..."
+                  {...register("fullname", {
+                    required: true,
+                    maxLength: { value: 20, message: "Must be < 20 letters" },
+                  })}
+                  className={`input mb-4 ${errors.fullname ? "border-red-500/80" : "border-white/30"}`}
+                />
+                {errors.fullname && (
+                  <p className="text-sm text-red-700">{errors.fullname.message}</p>
+                )}
+              </div>
+
+              {/* Email */}
+              <div>
+                <label className="label">Email</label>
+                <input
+                  type="email"
+                  placeholder="XXX@ABC.com"
+                  {...register("email", {
+                    required: true,
+                    pattern: {
+                      value: /^[a-zA-Z0-9._%+-]+[@][a-zA-Z0-9.-]+[.][a-zA-Z]{2,}$/,
+                      message: "Wrong email format",
+                    },
+                  })}
+                  className={`input mb-4 ${errors.email ? "border-red-500/80" : "border-white/30"}`}
+                />
+                {errors.email && (
+                  <p className="text-sm text-red-700">{errors.email.message}</p>
+                )}
+              </div>
+
+              {/* Phone */}
+              <div>
+                <label className="label">Phone</label>
+                <input
+                  type="number"
+                  placeholder="+91 XXX XXX"
+                  {...register("phone")}
+                  className={`input mb-4 ${errors.phone ? "border-red-500/80" : "border-white/30"}`}
+                />
+              </div>
+
+              {/* Date of Birth */}
+              <div className="w-full relative">
+                <label className="label">Date of Birth</label>
+                <div className="relative">
+                  <input
+                    type="text"
+                    placeholder="DD/MM/YYYY"
+                    {...register("DOB", {
+                      required: "Date of Birth is Required",
+                      pattern: {
+                        value: /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/,
+                        message: "Use DD/MM/YYYY Format",
+                      },
+                      validate: {
+                        notFuture: (value) => {
+                          const [day, month, year] = value.split("/").map(Number);
+                          const dob = new Date(year, month - 1, day);
+                          const minDate = new Date();
+                          minDate.setHours(0, 0, 0, 0);
+                          return dob < minDate || "Date of Birth should not be today or later";
+                        },
+                      },
+                    })}
+                    className={`input mb-4 pr-10 ${errors.DOB ? "border-red-500/80" : "border-white/30"}`}
+                    readOnly
+                  />
+                  <Calendar
+                    className="absolute right-3 top-1/2 -translate-y-1/2 h-full cursor-pointer hover:text-[#5dcaa5] transition-colors"
+                    onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+                  />
+                  {isCalendarOpen && (
+                    <CalendarPicker
+                      selectedDate={watch("DOB")}
+                      onSelect={(formatted) => {
+                        setValue("DOB", formatted);
+                      }}
+                      onClose={() => setIsCalendarOpen(false)}
+                    />
+                  )}
+                </div>
+                {errors.DOB && (
+                  <p className="text-sm text-red-700">{errors.DOB.message}</p>
+                )}
+              </div>
+
+              {/* Gender */}
+              <div>
+                <div className="flex gap-2.5">
+                  {["male", "female"].map((g) => (
+                    <label
+                      key={g}
+                      className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl border border-white/12 bg-white/5 text-sm text-white/50 cursor-pointer has-checked:border-[#1d9e75] has-checked:bg-[#1d9e75]/15 has-checked:text-[#5dcaa5] has-checked:font-medium transition-all"
+                    >
+                      <input
+                        type="radio"
+                        value={g}
+                        {...register("gender", {
+                          required: { value: true, message: "Required" },
+                        })}
+                        className="hidden"
+                      />
+                      {g === "male" ? "♂" : "♀"}{" "}
+                      {g.charAt(0).toUpperCase() + g.slice(1)}
+                    </label>
+                  ))}
+                </div>
+                {errors.gender && (
+                  <p className="text-xs text-red-400 mt-1">{errors.gender.message}</p>
+                )}
+              </div>
+
+              {/* Password */}
+              <div>
+                <fieldset
+                  className={`input mb-4 ${errors.password ? "border-red-500/80" : "border-white/30"}`}
                 >
                   <input
-                    type="radio"
-                    value={g}
-                    {...register("gender", {
-                      required: { value: true, message: "Required" },
+                    type={show ? "text" : "password"}
+                    placeholder="Enter Password"
+                    {...register("password", {
+                      required: true,
+                      pattern: {
+                        value: /[a-zA-z0-9_\-.@$]{7,16}/i,
+                        message: "Need 7-16 chars, special characters allowed",
+                      },
                     })}
-                    className="hidden"
+                    className="transparent w-full h-full focus:outline-none focus:ring-0"
                   />
-                  {g === "male" ? "♂" : "♀"}{" "}
-                  {g.charAt(0).toUpperCase() + g.slice(1)}
-                </label>
-              ))}
-            </div>
-            {errors.gender && (
-              <p className="text-xs text-red-400 mt-1">
-                {errors.gender.message}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <fieldset
-              className={`input mb-4 ${errors.password ? "border-red-500/80" : "border-white/30"}`}
-            >
-              <input
-                type={show ? "text" : "password"}
-                placeholder="Enter Password"
-                {...register("password", {
-                  required: true,
-                  pattern: {
-                    value: /[a-zA-z0-9_\-.@$]{7,16}/i,
-                    message: "Need 7-16,special Character,uppercase",
-                  },
-                })}
-                className="transparent w-full h-full focus:outline-none focus:ring-0"
-              />
-              <div
-                onClick={() => setShow((e) => (e = !e))}
-                className="cursor-pointer"
-              >
-                {show ? <Eye /> : <EyeClosed />}
+                  <div
+                    onClick={() => setShow((e) => !e)}
+                    className="cursor-pointer"
+                  >
+                    {show ? <Eye /> : <EyeClosed />}
+                  </div>
+                </fieldset>
+                {errors.password && (
+                  <p className="text-sm text-red-700">{errors.password.message}</p>
+                )}
               </div>
-            </fieldset>
-            {errors.password && (
-              <p className="text-sm text-red-700">{errors.password.message}</p>
-            )}
-          </div>
 
-          <button
-            type="submit"
-            className="w-full border border-white/20 rounded-md h-9 bg-linear-to-r from-teal-400 via-teal-800 to-blue-400 cursor-pointer hover:from-teal-600 hover:to-blue-800 hover:scale-105 transition-all hover:duration-200"
-          >
-            Create Account
-          </button>
-        </form>
+              <button
+                type="submit"
+                disabled={sendingOtp}
+                className="w-full border border-white/20 rounded-md h-9 bg-linear-to-r from-teal-400 via-teal-800 to-blue-400 cursor-pointer hover:from-teal-600 hover:to-blue-800 hover:scale-105 transition-all hover:duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              >
+                {sendingOtp ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    Sending OTP…
+                  </span>
+                ) : (
+                  "Continue →"
+                )}
+              </button>
+            </form>
+          </>
+        )}
       </div>
     </section>
   );
 };
+
 
 export default Signup;

--- a/Backend/controllers/OtpController.js
+++ b/Backend/controllers/OtpController.js
@@ -1,0 +1,229 @@
+import crypto from "crypto";
+import { Otp } from "../models/Otp.js";
+import { User } from "../models/Users.js";
+import { normalizeEmail } from "../utils/normalizeEmail.js";
+import { sendOtpEmail } from "../utils/sendOtpEmail.js";
+import { hashSync } from "bcrypt";
+import { signupVal } from "../utils/zodValidation.js";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+const MAX_ATTEMPTS      = 5;
+const RESEND_COOLDOWN_MS = 60 * 1000; // 1 minute between resends
+
+/** Cryptographically secure 6-digit OTP. */
+const generateOtp = () => String(crypto.randomInt(100000, 999999));
+
+/** UUID v4 used as the client-facing session key (never exposes email). */
+const generateSessionId = () => crypto.randomUUID();
+
+// ─── POST /api/auth/send-otp ─────────────────────────────────────────────────
+/**
+ * Creates a new OTP session for the given email.
+ * Returns { success, sessionId } — the client stores sessionId in localStorage
+ * and passes it to verify-otp, resend-otp, and signup instead of the email.
+ */
+export const sendOtp = async (req, res) => {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ success: false, message: "Email is required" });
+  }
+
+  const normalizedEmail = normalizeEmail(email);
+
+  try {
+    // Block if an account with this email already exists
+    const existingUser = await User.findOne({ email: normalizedEmail });
+    if (existingUser) {
+      return res.status(400).json({ success: false, message: "Email already registered" });
+    }
+
+    // Remove any stale sessions for this email before creating a fresh one
+    await Otp.deleteMany({ email: normalizedEmail });
+
+    const sessionId  = generateSessionId();
+    const plainOtp   = generateOtp();
+    const otpDoc     = new Otp({ sessionId, email: normalizedEmail });
+    otpDoc.setOtp(plainOtp);
+    await otpDoc.save();
+
+    // Fire-and-forget is intentional: we respond immediately so the UI feels fast.
+    // Email delivery failure is surfaced via the catch block below.
+    await sendOtpEmail(normalizedEmail, plainOtp);
+
+    return res.status(200).json({
+      success: true,
+      message: "OTP sent successfully",
+      sessionId,           // ← client saves this to localStorage
+    });
+  } catch (error) {
+    console.error("sendOtp error:", error);
+    return res.status(500).json({ success: false, message: "Failed to send OTP" });
+  }
+};
+
+// ─── POST /api/auth/resend-otp ───────────────────────────────────────────────
+/**
+ * Regenerates the OTP for an existing session.
+ * Requires { sessionId } in the body — no email needed.
+ * Enforces a 60-second cooldown via lastSentAt.
+ */
+export const resendOtp = async (req, res) => {
+  const { sessionId } = req.body;
+
+  if (!sessionId) {
+    return res.status(400).json({ success: false, message: "Session ID is required" });
+  }
+
+  try {
+    const otpDoc = await Otp.findOne({ sessionId, verified: false });
+
+    if (!otpDoc) {
+      return res.status(404).json({
+        success: false,
+        message: "Session not found or already verified. Please start over.",
+      });
+    }
+
+    // Cooldown guard
+    const elapsed = Date.now() - new Date(otpDoc.lastSentAt).getTime();
+    if (elapsed < RESEND_COOLDOWN_MS) {
+      const waitSecs = Math.ceil((RESEND_COOLDOWN_MS - elapsed) / 1000);
+      return res.status(429).json({
+        success: false,
+        message: `Please wait ${waitSecs}s before resending`,
+      });
+    }
+
+    // Generate a new OTP and overwrite the hash in the same document.
+    // The sessionId stays the same — client does not need to update localStorage.
+    const plainOtp = generateOtp();
+    otpDoc.setOtp(plainOtp); // also resets attempts and bumps lastSentAt
+    await otpDoc.save();
+
+    await sendOtpEmail(otpDoc.email, plainOtp);
+
+    return res.status(200).json({ success: true, message: "OTP resent successfully" });
+  } catch (error) {
+    console.error("resendOtp error:", error);
+    return res.status(500).json({ success: false, message: "Failed to resend OTP" });
+  }
+};
+
+// ─── POST /api/auth/verify-otp ───────────────────────────────────────────────
+/**
+ * Verifies the OTP for a given session.
+ * Requires { sessionId, otp } — no email in the request body.
+ */
+export const verifyOtp = async (req, res) => {
+  const { sessionId, otp } = req.body;
+
+  if (!sessionId || !otp) {
+    return res.status(400).json({ success: false, message: "Session ID and OTP are required" });
+  }
+
+  try {
+    const otpDoc = await Otp.findOne({ sessionId, verified: false });
+
+    if (!otpDoc) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid or expired session. Please request a new OTP.",
+      });
+    }
+
+    // Application-level expiry check (5 min), independent of the DB TTL (10 min)
+    if (new Date() > otpDoc.expiresAt) {
+      await otpDoc.deleteOne();
+      return res.status(400).json({
+        success: false,
+        message: "OTP expired. Please request a new one.",
+        expired: true,        // client can use this flag to auto-trigger resend UI
+      });
+    }
+
+    // Max attempts guard
+    if (otpDoc.attempts >= MAX_ATTEMPTS) {
+      await otpDoc.deleteOne();
+      return res.status(429).json({
+        success: false,
+        message: "Too many failed attempts. Please request a new OTP.",
+        locked: true,
+      });
+    }
+
+    const isValid = otpDoc.verifyOtp(otp);
+
+    if (!isValid) {
+      otpDoc.attempts += 1;
+      await otpDoc.save();
+      const remaining = MAX_ATTEMPTS - otpDoc.attempts;
+      return res.status(400).json({
+        success: false,
+        message: `Invalid OTP. ${remaining} attempt${remaining === 1 ? "" : "s"} remaining`,
+        attemptsRemaining: remaining,
+      });
+    }
+
+    // Mark session as verified — signup will check this
+    otpDoc.verified = true;
+    await otpDoc.save();
+
+    return res.status(200).json({ success: true, message: "Email verified successfully" });
+  } catch (error) {
+    console.error("verifyOtp error:", error);
+    return res.status(500).json({ success: false, message: "OTP verification failed" });
+  }
+};
+
+// ─── POST /api/auth/signup (OTP-gated) ──────────────────────────────────────
+/**
+ * Creates the user account.
+ * Requires { sessionId, ...formFields } — email comes from the verified OTP session,
+ * NOT from the request body, preventing email substitution attacks.
+ */
+export const SingupAuth = async (req, res) => {
+  const { sessionId, ...rest } = req.body;
+
+  if (!sessionId) {
+    return res.status(400).json({ success: false, message: "Session ID is required" });
+  }
+
+  try {
+    // Load the verified session — this also gives us the trusted email
+    const otpDoc = await Otp.findOne({ sessionId, verified: true });
+    if (!otpDoc) {
+      return res.status(403).json({
+        success: false,
+        message: "Email not verified. Please complete OTP verification first.",
+      });
+    }
+
+    // Merge the session email into the body for Zod validation
+    const payload = { ...rest, email: otpDoc.email };
+    const result  = signupVal.safeParse(payload);
+
+    if (!result.success) {
+      return res.status(400).json({ errors: result.error.format() });
+    }
+
+    const { fullname, email, phone, gender, password, DOB } = result.data;
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      return res.status(400).json({ success: false, message: "User already exists" });
+    }
+
+    const hashedPassword = hashSync(password, 10);
+
+    await User.create({ fullname, email, phone, gender, password: hashedPassword, DOB });
+
+    // Clean up the OTP session — it's been consumed
+    await otpDoc.deleteOne();
+
+    return res.status(201).json({ success: true, message: "Sign Up Successful" });
+  } catch (error) {
+    console.error("SingupAuth error:", error);
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/Backend/controllers/authController.js
+++ b/Backend/controllers/authController.js
@@ -1,64 +1,16 @@
-import { compareSync, hashSync } from "bcrypt";
+import { compareSync } from "bcrypt";
 import jwt from "jsonwebtoken";
-import { LoginVal, signupVal } from "../utils/zodValidation.js";
+import { LoginVal } from "../utils/zodValidation.js";
 import { User } from "../models/Users.js";
 import { v2 as cloudinary } from "cloudinary";
 import { normalizeEmail } from "../utils/normalizeEmail.js";
+import fs from "fs";
 
 cloudinary.config({
   cloud_name: process.env.CLOUD_NAME,
   api_key: process.env.CLOUD_API_KEY,
   api_secret: process.env.CLOUD_SECRET,
 });
-
-//Signup auth
-export const SingupAuth = async (req, res) => {
-  const result = signupVal.safeParse(req.body);
-  console.log(req.body);
-  console.log(result);
-
-  if (!result.success) {
-    return res.json({
-      errors: result.error.format(),
-    });
-  }
-
-  const { fullname, email, phone, gender, password, DOB } = result.data;
-  const hashedPassword = hashSync(password, 10);
-  const normalizedEmail = normalizeEmail(email);
-
-  try {
-    const existingUser = await User.findOne({
-      email: normalizedEmail,
-    });
-
-    if (existingUser) {
-      return res.status(400).json({
-        success: false,
-        message: "User already exists",
-      });
-    }
-
-    await User.create({
-      fullname,
-      email: normalizedEmail,
-      phone,
-      gender,
-      password: hashedPassword,
-      DOB,
-    });
-
-    res.json({
-      success: true,
-      message: "Sign Up Successful",
-    });
-  } catch (error) {
-    res.json({
-      success: false,
-      message: error.message,
-    });
-  }
-};
 
 //login Auth
 export const LoginAuth = async (req, res) => {
@@ -119,25 +71,35 @@ export const refesh = async (req, res) => {
   try {
     if (!token) {
       return res.status(401).json({
+        success: false,
         message: "token not present",
       });
     }
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     if (!decoded) {
       return res.status(401).json({
+        success: false,
         message: "invalid token",
       });
     }
     const user = await User.findOne({ _id: decoded.id });
     // console.log(user);
 
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: "User not found",
+      });
+    }
+
     const newAccessToken = user.generateAccessToken();
 
-    res.json({
+    res.status(200).json({
+      success: true,
       accessToken: newAccessToken,
     });
   } catch (error) {
-    res.json({
+    res.status(401).json({
       success: false,
       message: error.message,
     });
@@ -153,13 +115,18 @@ export const logout = (req, res) => {
 };
 
 export const editUser = async (req, res) => {
-  const profilePicture = req.file.path;
   const { fullname, phone, address, DOB } = req.body;
-  // console.log(req.user._id);
-  // console.log(DOB);
 
   try {
-    const profileUrl = await cloudinary.uploader.upload(profilePicture);
+    let imageUrl;
+
+    if (req.file) {
+      const profileUrl = await cloudinary.uploader.upload(req.file.path);
+      imageUrl = profileUrl.url;
+      fs.unlink(req.file.path, (err) => {
+        if (err) console.error("Failed to delete temp file:", err);
+      });
+    }
 
     await User.findByIdAndUpdate(
       req.user._id,
@@ -167,13 +134,11 @@ export const editUser = async (req, res) => {
         fullname,
         phone,
         state: address,
-        DOB: DOB,
-        image: profileUrl.url,
+        DOB,
+        ...(imageUrl && { image: imageUrl }),
       },
       { returnDocument: "after" },
     );
-
-    // console.log(user);
 
     res.json({
       success: true,
@@ -181,7 +146,7 @@ export const editUser = async (req, res) => {
     });
   } catch (error) {
     console.log(error);
-    res.json({
+    res.status(500).json({
       success: false,
       message: error.message,
     });

--- a/Backend/models/Otp.js
+++ b/Backend/models/Otp.js
@@ -1,0 +1,88 @@
+import mongoose from "mongoose";
+import { hashSync, compareSync } from "bcrypt";
+
+/**
+ * Otp document lifecycle:
+ *
+ *  send-otp  → creates doc  { sessionId (UUID), email, otpHash, expiresAt, verified:false }
+ *  verify-otp → finds by sessionId, checks hash → sets verified:true
+ *  resend-otp → finds by sessionId, replaces otpHash + resets expiresAt (cooldown enforced)
+ *  signup     → finds by sessionId + verified:true → creates User → deletes doc
+ *
+ * MongoDB TTL index hard-deletes the entire document 10 minutes after createdAt,
+ * so abandoned sessions are cleaned up automatically even if the user closes the tab.
+ */
+const OtpSchema = new mongoose.Schema({
+  // UUID returned to the client; used as the lookup key instead of exposing email
+  sessionId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+
+  email: {
+    type: String,
+    required: true,
+    lowercase: true,
+    trim: true,
+  },
+
+  // bcrypt hash of the 6-digit OTP (rounds: 8 for fast verify UX)
+  otpHash: {
+    type: String,
+    required: true,
+  },
+
+  // Hard expiry checked in application logic (5 minutes)
+  expiresAt: {
+    type: Date,
+    required: true,
+  },
+
+  // Tracks wrong guesses; session is killed after MAX_ATTEMPTS
+  attempts: {
+    type: Number,
+    default: 0,
+  },
+
+  // Flipped to true by verify-otp; signup checks this before creating the User
+  verified: {
+    type: Boolean,
+    default: false,
+  },
+
+  // Timestamp for resend cooldown checks
+  lastSentAt: {
+    type: Date,
+    default: Date.now,
+  },
+
+  // TTL index: MongoDB auto-deletes the document 10 minutes after creation.
+  // This is a hard backstop — the app-level expiresAt (5 min) is the user-facing limit.
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    expires: 600, // 10 minutes in seconds
+  },
+});
+
+/**
+ * Hash the OTP and set expiry. Call this on both send and resend.
+ * Uses bcrypt rounds=8: fast enough for a good UX (~80ms) while still secure.
+ */
+OtpSchema.methods.setOtp = function (plainOtp) {
+  this.otpHash = hashSync(plainOtp, 8);
+  this.expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes from now
+  this.lastSentAt = new Date();
+  this.attempts = 0; // reset attempts on every fresh OTP
+};
+
+/** Compare a plain OTP against the stored hash. */
+OtpSchema.methods.verifyOtp = function (plainOtp) {
+  return compareSync(plainOtp, this.otpHash);
+};
+
+const Otp = mongoose.model("Otp", OtpSchema);
+
+export { Otp };

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -17,11 +17,12 @@
         "cors": "^2.8.6",
         "dayjs": "^1.11.20",
         "dob-to-age": "^4.0.0",
-        "dotenv": "^17.3.1",
+        "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.1.5",
         "multer": "^2.1.1",
+        "nodemailer": "^8.0.10",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "zod": "^4.3.6"
@@ -302,6 +303,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -740,9 +742,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -859,6 +861,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1990,6 +1993,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -22,11 +22,12 @@
     "cors": "^2.8.6",
     "dayjs": "^1.11.20",
     "dob-to-age": "^4.0.0",
-    "dotenv": "^17.3.1",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.1.5",
     "multer": "^2.1.1",
+    "nodemailer": "^8.0.10",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "zod": "^4.3.6"

--- a/Backend/routes/userRoutes.js
+++ b/Backend/routes/userRoutes.js
@@ -2,13 +2,42 @@ import { Router } from "express";
 import {
   LoginAuth,
   logout,
-  SingupAuth,
+  getUser,
+  editUser,
+  refesh,
 } from "../controllers/authController.js";
+import { sendOtp, resendOtp, verifyOtp, SingupAuth } from "../controllers/OtpController.js";
+import passport from "passport";
+import multer from "multer";
 
+const upload = multer({
+  dest: "uploads/",
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith("image/")) {
+      cb(null, true);
+    } else {
+      cb(new Error("Only image files are allowed"), false);
+    }
+  },
+});
 const router = Router();
+
+// OTP endpoints
+router.post("/send-otp",   sendOtp);
+router.post("/resend-otp", resendOtp);
+router.post("/verify-otp", verifyOtp);
 
 router.post("/signup", SingupAuth);
 router.post("/login", LoginAuth);
 router.post("/logout", logout);
+router.post("/refresh", refesh);
+router.get("/me", passport.authenticate("jwt", { session: false }), getUser);
+router.patch(
+  "/edit",
+  passport.authenticate("jwt", { session: false }),
+  upload.single("profile_picture"),
+  editUser,
+);
 
 export default router;

--- a/Backend/utils/sendOtpEmail.js
+++ b/Backend/utils/sendOtpEmail.js
@@ -1,0 +1,47 @@
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS, // Use an App Password, not your real Gmail password
+  },
+  logger:true,
+  debug:true,
+});
+transporter.verify((error, success) => {
+  if (error) {
+    console.error("VERIFY ERROR:", error);
+  } else {
+    console.log("Mail server ready");
+  }
+});
+
+/**
+ * Send OTP email to a user.
+ * @param {string} to  - recipient email
+ * @param {string} otp - plain 6-digit OTP
+ */
+export const sendOtpEmail = async (to, otp) => {
+  const mailOptions = {
+    from: `"AthLead Security" <${process.env.EMAIL_USER}>`,
+    to,
+    subject: "Your AthLead Verification OTP",
+    html: `
+      <div style="font-family:sans-serif;max-width:480px;margin:auto;padding:32px;border:1px solid #e5e7eb;border-radius:12px;background:#f9fafb">
+        <h2 style="color:#0f172a;margin-bottom:8px">Email Verification</h2>
+        <p style="color:#475569;margin-bottom:24px">Use the OTP below to verify your email. It is valid for <strong>5 minutes</strong>.</p>
+        <div style="background:#1e293b;color:#5dcaa5;font-size:32px;font-weight:700;letter-spacing:12px;text-align:center;padding:20px;border-radius:8px">
+          ${otp}
+        </div>
+        <p style="color:#94a3b8;font-size:12px;margin-top:24px">If you did not request this, please ignore this email. Do not share your OTP with anyone.</p>
+      </div>
+    `,
+  };
+
+  //await transporter.sendMail(mailOptions);
+  const info = await transporter.sendMail(mailOptions);
+
+console.log("EMAIL SENT");
+console.log(info);
+};


### PR DESCRIPTION
## Summary
Implements OTP-based email verification during signup as requested in #31.

## Changes
- `Backend/models/Otp.js` — Mongoose schema with sessionId UUID, bcrypt hash, TTL 10min
- `Backend/controllers/otpController.js` — sendOtp, resendOtp, verifyOtp, SingupAuth
- `Backend/utils/sendOtpEmail.js` — Nodemailer HTML email template
- `Backend/routes/userRoutes.js` — 3 new OTP endpoints
- `Athlead-client/src/Components/OtpVerification.jsx` — 6-digit input, resend cooldown
- `Athlead-client/src/pages/Signup.jsx` — 3-step flow: form → OTP → account created

## How to test
1. Add EMAIL_USER and EMAIL_PASS (Gmail App Password) to Backend/.env
2. Go to /signup and fill the form
3. Check email for OTP → enter it → account is created

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email-based OTP verification for account signup with resend functionality and cooldown gating
  * Two-step signup flow: form submission followed by OTP verification
  * Profile picture upload capability for user profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->