### PR TITLE
feat: add search and category filter to Announcements page

### DIFF
--- a/Athlead-client/src/pages/Announcement.jsx
+++ b/Athlead-client/src/pages/Announcement.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { api } from "../api/axios";
-import toast from "react-hot-toast";
 import NewsCard from "../Components/NewsCard";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
@@ -22,7 +21,7 @@ const Announcement = () => {
       } else {
         setNews(localAnnouncements);
       }
-    } catch (error) {
+    } catch {
       console.warn("API unavailable, using local announcements fallback");
       setNews(localAnnouncements);
     }
@@ -49,9 +48,9 @@ const Announcement = () => {
   // Apply search + category filter together
   const filteredNews = useMemo(() => {
     return news.filter((item) => {
-      const matchesSearch = item.title
-        ?.toLowerCase()
-        .includes(searchQuery.toLowerCase());
+      const matchesSearch =
+        !searchQuery ||
+        item.title?.toLowerCase().includes(searchQuery.toLowerCase());
 
       const matchesCategory =
         activeCategory === "All" ||
@@ -91,6 +90,7 @@ const Announcement = () => {
         <div className="w-full max-w-4xl flex flex-col gap-4 mb-6">
           <input
             type="text"
+            aria-label="Search announcements by title"
             placeholder="Search announcements by title..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -102,6 +102,7 @@ const Announcement = () => {
               <button
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
+                aria-pressed={activeCategory === cat}
                 className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
                   activeCategory === cat
                     ? "bg-teal-500 text-black border-teal-500"

--- a/Athlead-client/src/pages/Announcement.jsx
+++ b/Athlead-client/src/pages/Announcement.jsx
@@ -1,37 +1,74 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { api } from "../api/axios";
 import toast from "react-hot-toast";
 import NewsCard from "../Components/NewsCard";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 import { BentoGridDemo } from "../Components/Bento";
+import { announcements as localAnnouncements } from "../assets/assets.js";
 
 const Announcement = () => {
   const [news, setNews] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState("All");
+
   const getNews = async () => {
     try {
       setIsLoading(true);
       const { data } = await api.get("/api/news");
-      // console.log(data);
-
-      if (data.success) {
+      if (data.success && data.message.length > 0) {
         setNews(data.message);
+      } else {
+        setNews(localAnnouncements);
       }
     } catch (error) {
-      toast.error(error.message);
+      console.warn("API unavailable, using local announcements fallback");
+      setNews(localAnnouncements);
     }
   };
+
   useEffect(() => {
     getNews()
       .then(() => setIsLoading(false))
       .catch(() => setIsLoading(false));
   }, []);
 
+  // Build category list dynamically from type + tags fields (case-insensitive dedup)
+  const categories = useMemo(() => {
+    const map = new Map(); // lowercase -> original display casing
+    news.forEach((item) => {
+      if (item.type) map.set(item.type.toLowerCase(), item.type);
+      if (Array.isArray(item.tags)) {
+        item.tags.forEach((t) => map.set(t.toLowerCase(), t));
+      }
+    });
+    return ["All", ...Array.from(map.values())];
+  }, [news]);
+
+  // Apply search + category filter together
+  const filteredNews = useMemo(() => {
+    return news.filter((item) => {
+      const matchesSearch = item.title
+        ?.toLowerCase()
+        .includes(searchQuery.toLowerCase());
+
+      const matchesCategory =
+        activeCategory === "All" ||
+        item.type?.toLowerCase() === activeCategory.toLowerCase() ||
+        (Array.isArray(item.tags) &&
+          item.tags.some(
+            (t) => t.toLowerCase() === activeCategory.toLowerCase(),
+          ));
+
+      return matchesSearch && matchesCategory;
+    });
+  }, [news, searchQuery, activeCategory]);
+
   if (!isLoading && news.length === 0) {
     return (
       <section className="relative min-h-screen flex flex-col items-center justify-center mt-10 mx-6">
-        <div className="flex item-center justify-center w-full max-w-4xl  text-lg lg:text-2xl  mb-6 ">
+        <div className="flex item-center justify-center w-full max-w-4xl text-lg lg:text-2xl mb-6">
           <p className="text-white text-3xl">No news available</p>
         </div>
       </section>
@@ -40,7 +77,7 @@ const Announcement = () => {
 
   return (
     <section className="relative min-h-screen flex flex-col items-center justify-center mt-10 mx-6">
-      <div className="flex item-start w-full max-w-4xl  text-lg lg:text-2xl  mb-6 ">
+      <div className="flex item-start w-full max-w-4xl text-lg lg:text-2xl mb-6">
         <p className="bg-linear-to-b from-teal-600 to-blue-500 font-extrabold mx-1 bg-clip-text text-transparent">
           |
         </p>
@@ -49,14 +86,44 @@ const Announcement = () => {
         </p>
       </div>
 
-      <BentoGridDemo items={news} isLoading={isLoading} />
-      {/* <div className="grid grid-col-1 max-w-4xl w-full items-center justify-start gap-5">
-        {isLoading
-          ? Array(5)
-              .fill(0)
-              .map((_, i) => <NewsCard key={i} loading={isLoading} />)
-          : news.map((e, i) => <NewsCard e={e} key={i} />)}
-      </div> */}
+      {/* Search + Filter Bar */}
+      {!isLoading && (
+        <div className="w-full max-w-4xl flex flex-col gap-4 mb-6">
+          <input
+            type="text"
+            placeholder="Search announcements by title..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full px-4 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-white placeholder-neutral-500 focus:outline-none focus:border-teal-500 transition-colors"
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setActiveCategory(cat)}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                  activeCategory === cat
+                    ? "bg-teal-500 text-black border-teal-500"
+                    : "bg-transparent text-neutral-300 border-neutral-700 hover:border-teal-500"
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!isLoading && filteredNews.length === 0 ? (
+        <div className="flex items-center justify-center w-full max-w-4xl text-lg mb-6">
+          <p className="text-neutral-400 text-xl">
+            No announcements match your search.
+          </p>
+        </div>
+      ) : (
+        <BentoGridDemo items={filteredNews} isLoading={isLoading} />
+      )}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
Adds search and category filtering to the Announcements page as requested in #53.

## Changes
- Added a search input that filters announcements by title in real-time (case-insensitive)
- Added dynamically-generated category filter buttons based on each announcement's `type` and `tags` fields (deduplicated, case-insensitive)
- "All" category resets the filter
- Search and category filters combine (AND logic)
- Empty state message shown when no results match
- Falls back to local announcement data (`assets.js`) when the `/api/news` endpoint is unavailable or returns empty, so the feature is testable without backend setup
- Filtering is fully client-side — no additional API calls
- Verified responsive layout on mobile, tablet, and desktop widths
- Existing BentoGrid layout and article cards unchanged

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a search and category filter bar for announcements with case-insensitive title matching.
  * Automatically generates deduplicated categories from announcement types and tags.
  * Displays a “No announcements match your search” message when filters return no results.
* **Bug Fixes**
  * Improved announcements loading so remote failures or unsuccessful responses reliably fall back to local announcements.
  * Ensures users see only the filtered results while searching or applying categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->