### PR TITLE
fix: close event details modal before registration navigation

### DIFF
--- a/Athlead-client/src/Components/EventDetails.jsx
+++ b/Athlead-client/src/Components/EventDetails.jsx
@@ -75,7 +75,10 @@ const EventDetails = ({ selected, setIsOpen }) => {
         </div>
         <div className="flex items-center justify-center max-w-3xl">
           <button
-            onClick={() => navigate(`/events/${selected._id}`)}
+            onClick={() => {
+              setIsOpen(false);
+              navigate(`/events/${selected._id}`);
+            }}
             className="text-center bg-linear-to-br from-cyan-400 to-cyan-600 w-full rounded-xl h-10 max-w-120 hover:from-cyan-600 hover:to-cyan-800 mx-4"
           >
             Register Now


### PR DESCRIPTION
## Description

Closes #86

This PR completes the remaining navigation behavior for the EventDetails registration flow.

The current `main` branch already uses the selected event ID when navigating from `EventDetails.jsx`. This change ensures that the EventDetails modal is closed before navigating to the event signup route.

The resulting flow is:

`EventDetails modal → Register Now → modal closes → /events/<event_id> → EventSignup`

The existing EventCard registration flow remains unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Design update

## Acceptance Criteria

- [x] "Register Now" in `EventDetails.jsx` navigates to the correct dynamic event route.
- [x] Navigation follows the same dynamic event ID pattern used by `EventCard.jsx`.
- [x] EventDetails modal closes before navigation.
- [x] `setIsOpen(false)` is called prior to route transition.
- [x] `EventSignup` receives the `eventId` through the URL parameter.
- [x] Existing `EventCard` registration flow remains unchanged.
- [x] No hardcoded `/events/:eventId` navigation is introduced by this change.

## Visual Previews

No visual UI changes were introduced. This PR only updates the registration navigation behavior.

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [x] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The event details modal now closes automatically before navigating to the selected event page after registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->