### PR TITLE
fix: dashboard data not rendering immediately after login

### DIFF
--- a/Athlead-client/src/pages/Login.jsx
+++ b/Athlead-client/src/pages/Login.jsx
@@ -13,16 +13,19 @@ const Login = () => {
     formState: { errors },
   } = useForm();
   const [show, setShow] = useState(false);
-  const { setLoggedIn } = useAuth();
+  const { setLoggedIn, fetchUser } = useAuth();
 
   const navigate = useNavigate();
 
   const onSubmit = async (data) => {
     const res = await api.post("/api/auth/login", data);
 
-    localStorage.setItem("accessToken", res.data.accessToken);
-    setLoggedIn(true);
     if (res.data.success) {
+      localStorage.setItem("accessToken", res.data.accessToken);
+
+      setLoggedIn(true);
+      await fetchUser();
+
       toast.success(res.data.message);
       navigate("/dashboard");
     } else {


### PR DESCRIPTION
## Description

Fixes an issue where dashboard data and the user's profile image did not render immediately after login.

The login flow was redirecting to the dashboard before the authenticated user data had been fetched. This PR updates the login flow to fetch the current user after storing the access token and before navigating to the dashboard.

Closes Issue #89


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Design update

## Visual Previews

No UI changes.

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [x] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login handling to update authentication state only after a successful response.
  * Prevented failed login attempts from storing access tokens or changing logged-in status.
  * Ensured success messages and navigation occur only after user data is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->