### PR TITLE
fix: balance dashboard chart layout

### DIFF
--- a/Athlead-client/src/Components/DashboardSkeleton.jsx
+++ b/Athlead-client/src/Components/DashboardSkeleton.jsx
@@ -25,8 +25,8 @@ export const LeaderboardSkeleton = () => (
   </>
 );
 
-export const ChartSkeleton = () => (
-  <div className="h-62.5 flex items-center justify-center">
+export const ChartSkeleton = ({ className = "h-62.5" }) => (
+  <div className={`${className} flex items-center justify-center`}>
     <Skeleton className="w-full h-full rounded-xl" />
   </div>
 );

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -299,7 +299,7 @@ const Dashboard = () => {
         <div className="min-h-[360px] flex flex-col bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-xl shadow-xl">
           <div className="min-h-[300px] flex-1 flex items-center justify-center p-3 sm:p-5">
             {dashboardLoading ? (
-              <ChartSkeleton />
+              <ChartSkeleton className="w-full h-[300px]" />
             ) : radarChartData.length === 0 ? (
               <div className="h-full min-h-[300px] flex flex-col items-center justify-center text-center px-6">
                 <p className="text-gray-300 font-medium">
@@ -346,7 +346,7 @@ const Dashboard = () => {
         </div>
         <div className="min-h-[360px] flex items-center py-5 px-3 sm:p-5 bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-2xl shadow-xl">
           {dashboardLoading ? (
-            <ChartSkeleton />
+            <ChartSkeleton className="w-full h-[300px]" />
           ) : scores.length === 0 ? (
             <div className="relative h-[300px] w-full">
               <div aria-hidden="true">

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -43,6 +43,17 @@ const Dashboard = () => {
   const { user } = useAuth();
   const [rank, setRank] = useState([]);
   const [registeredEvents, setRegisteredEvents] = useState([]);
+  const [compactCharts, setCompactCharts] = useState(
+    () => window.matchMedia("(max-width: 639px)").matches,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const updateChartSize = (event) => setCompactCharts(event.matches);
+
+    mediaQuery.addEventListener("change", updateChartSize);
+    return () => mediaQuery.removeEventListener("change", updateChartSize);
+  }, []);
 
   useEffect(() => {
     setRadarChartData([]);
@@ -284,13 +295,13 @@ const Dashboard = () => {
           </table>
         </div>
       </div>
-      <div className="w-full grid grid-cols-1 lg:grid-cols-3 px-10 mb-5 gap-5">
-        <div className=" bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-xl shadow-xl">
-          <div className="flex items-start justify-center">
+      <div className="w-full grid grid-cols-1 lg:grid-cols-2 px-4 sm:px-10 mb-5 gap-5">
+        <div className="min-h-[360px] flex flex-col bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-xl shadow-xl">
+          <div className="min-h-[300px] flex-1 flex items-center justify-center p-3 sm:p-5">
             {dashboardLoading ? (
               <ChartSkeleton />
             ) : radarChartData.length === 0 ? (
-              <div className="min-h-[300px] flex flex-col items-center justify-center text-center px-6">
+              <div className="h-full min-h-[300px] flex flex-col items-center justify-center text-center px-6">
                 <p className="text-gray-300 font-medium">
                   No score generated yet.
                 </p>
@@ -299,38 +310,31 @@ const Dashboard = () => {
                 </p>
               </div>
             ) : (
-              <RadarChart
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  maxWidth: "500px",
-                  maxHeight: "80vh",
-                  aspectRatio: 1,
-                }}
-                responsive
-                outerRadius="80%"
-                data={radarChartData}
-                margin={{
-                  top: 20,
-                  left: 20,
-                  right: 20,
-                  bottom: 20,
-                }}
-              >
-                <PolarGrid />
-                <PolarAngleAxis dataKey="metric" />
-                <PolarRadiusAxis />
-                <Radar
-                  name="aarsh"
-                  dataKey="value"
-                  stroke="#8884d8"
-                  fill="#8884d8"
-                  fillOpacity={0.6}
-                />
-              </RadarChart>
+              <ResponsiveContainer width="100%" height={300}>
+                <RadarChart
+                  outerRadius={compactCharts ? "52%" : "72%"}
+                  data={radarChartData}
+                  margin={{
+                    top: 20,
+                    left: 30,
+                    right: 30,
+                    bottom: 20,
+                  }}
+                >
+                  <PolarGrid />
+                  <PolarAngleAxis dataKey="metric" />
+                  <PolarRadiusAxis />
+                  <Radar
+                    name="aarsh"
+                    dataKey="value"
+                    stroke="#8884d8"
+                    fill="#8884d8"
+                    fillOpacity={0.6}
+                  />
+                </RadarChart>
+              </ResponsiveContainer>
             )}
           </div>
-          <div></div>
           <div className="flex items-center justify-center">
             <button
               onClick={() => navigate("/score")}
@@ -340,11 +344,11 @@ const Dashboard = () => {
             </button>
           </div>
         </div>
-        <div className="col-span-2  py-10  px-3 bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-2xl shadow-xl">
+        <div className="min-h-[360px] flex items-center py-5 px-3 sm:p-5 bg-linear-to-br from-[#0f2027] via-[#1a3a4a] to-[#0f2027] border border-[#1d9e75]/40 text-start text-white rounded-2xl shadow-xl">
           {dashboardLoading ? (
             <ChartSkeleton />
           ) : scores.length === 0 ? (
-            <div className="relative h-[250px]">
+            <div className="relative h-[300px] w-full">
               <div aria-hidden="true">
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={placeholderScores}>
@@ -373,7 +377,7 @@ const Dashboard = () => {
               </div>
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={250}>
+            <ResponsiveContainer width="100%" height={300}>
               <LineChart data={scores}>
                 <XAxis dataKey="date" className="text-xs" stroke="#888" />
                 <YAxis className="text-xs" stroke="#888" />


### PR DESCRIPTION
## Description

Balances the dashboard performance charts so the radar and line sections use equal proportions and consistent heights.

Changes include:

- replaces the one-third/two-thirds desktop grid with equal columns
- gives both cards a consistent 360px minimum height and both chart canvases a 300px height
- wraps the radar chart in ResponsiveContainer so it follows its card width
- reduces horizontal padding on small screens
- uses a compact radar radius below 640px so long metric labels remain visible
- keeps loading and empty states aligned with the populated chart dimensions

## Closes Issue #102

Closes #102

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Design update

## Visual Previews

Responsive layout verification:

| Viewport | Result |
| --- | --- |
| 1440 × 900 | Equal side-by-side chart cards with balanced chart canvases |
| 768 × 900 | Cards stack cleanly with consistent widths and no overflow |
| 390 × 844 | Cards remain within the viewport; compact radar radius prevents label clipping |

## Testing

- npx prettier --check src/pages/Dashboard.jsx
- npm run lint (frontend)
- npm run lint (backend)
- npm run build (frontend)
- manual responsive verification at desktop, tablet, and mobile widths

## Checklist

- [x] I tested my changes
- [x] I ran npm run lint
- [x] I ran npm run build
- [x] I ran npm run format
- [ ] I updated documentation

Documentation was not changed because this is a dashboard layout correction with no setup or usage changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dashboard chart layouts across desktop and mobile screen sizes.
  * Updated radar chart sizing and spacing for better responsive presentation.
  * Increased the populated performance chart height and refined empty-state dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->