### PR TITLE
Centralize date formatting in a shared dateFormatter utility

### DIFF
--- a/Athlead-client/src/Components/EventCard.jsx
+++ b/Athlead-client/src/Components/EventCard.jsx
@@ -3,15 +3,12 @@ import { sportIcon } from "../assets/assets";
 import { Calendar, Clock, MapPin, Medal } from "lucide-react";
 import { useNavigate } from "react-router";
 import { formatEventTime } from "../utils/formatEventTime";
+import { formatDate } from "../utils/dateFormatter";
 
 const EventCard = ({ e, setSelected, setIsOpen }) => {
   const navigate = useNavigate();
   const eventTime = formatEventTime(e.time);
-  const formattedDate = new Date(e.date).toLocaleDateString("en-IN", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
+  const formattedDate = formatDate(e.date, "D MMM YYYY");
   return (
     <div
       key={e.id}

--- a/Athlead-client/src/Components/EventDetails.jsx
+++ b/Athlead-client/src/Components/EventDetails.jsx
@@ -3,14 +3,11 @@ import { sportIcon } from "../assets/assets";
 import { Calendar, Clock, MapPin, Medal } from "lucide-react";
 import { useNavigate } from "react-router";
 import { formatEventTime } from "../utils/formatEventTime";
+import { formatDate } from "../utils/dateFormatter";
 
 const EventDetails = ({ selected, setIsOpen }) => {
   const navigate = useNavigate();
-  const formattedDate = new Date(selected.date).toLocaleDateString("en-IN", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
+  const formattedDate = formatDate(selected.date, "D MMM YYYY");
   const eventTime = formatEventTime(selected.time);
 
   return (

--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router";
 import { useEffect } from "react";
 import { api } from "../api/axios";
 import { useAuth } from "../context/useAuth";
-import dayjs from "dayjs";
+import { formatDate } from "../utils/dateFormatter";
 import EditForm from "../Components/EditForm";
 import {
   ProfileSkeleton,
@@ -127,7 +127,7 @@ const Dashboard = () => {
 
         const formattedScores = (scoresRes.data.scores || []).map((item) => ({
           ...item,
-          date: dayjs(item.date).format("DD MMM YY"),
+          date: formatDate(item.date, "DD MMM YY"),
         }));
 
         setScores(formattedScores);
@@ -204,7 +204,7 @@ const Dashboard = () => {
 
                     <p className="flex items-center">
                       <Calendar className="h-4 w-4 mr-1" />
-                      {dayjs(user?.DOB).format("DD MMM")}
+                      {formatDate(user?.DOB, "DD MMM")}
                     </p>
                   </div>
                 </div>
@@ -446,7 +446,7 @@ const Dashboard = () => {
               {registeredEvents.map((registration) => {
                 const event = registration.event || {};
                 const formattedDate = event.date
-                  ? dayjs(event.date).format("MMM D, YYYY")
+                  ? formatDate(event.date)
                   : "Date TBD";
 
                 return (

--- a/Athlead-client/src/pages/admin/AllEvents.jsx
+++ b/Athlead-client/src/pages/admin/AllEvents.jsx
@@ -1,4 +1,5 @@
 import { api } from "@/api/axios";
+import { formatDate } from "@/utils/dateFormatter";
 import React, { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import {
@@ -132,7 +133,7 @@ const AllEvents = () => {
             <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-600">
               <span className="flex items-center gap-1.5">
                 <Calendar size={14} className="text-slate-400" />
-                {new Date(event.date).toLocaleDateString()}
+                {formatDate(event.date, "D MMM YYYY")}
               </span>
               <span className="flex items-center gap-1.5">
                 <Clock size={14} className="text-slate-400" />

--- a/Athlead-client/src/utils/dateFormatter.js
+++ b/Athlead-client/src/utils/dateFormatter.js
@@ -1,0 +1,5 @@
+import dayjs from "dayjs";
+
+export const formatDate = (date, format = "MMM D, YYYY") => {
+  return dayjs(date).format(format);
+};


### PR DESCRIPTION
Fixes #106.

## Problem

Date formatting was implemented three different ways across the app:

- `Dashboard.jsx` used `dayjs()` directly, with three different format strings inline.
- `EventCard.jsx` and `EventDetails.jsx` used `new Date(...).toLocaleDateString("en-IN", { day: "numeric", month: "short", year: "numeric" })`.
- `AllEvents.jsx` used a bare `new Date(...).toLocaleDateString()` with no locale/options, so it silently fell back to whatever locale the viewer's browser reports - a real source of inconsistency, not just a style nit.

## Change

Added `Athlead-client/src/utils/dateFormatter.js`, exporting a single `formatDate(date, format = "MMM D, YYYY")` backed by `dayjs` (already a project dependency - no new packages). It follows the same pattern as the existing `utils/formatEventTime.js`.

Routed all four components through it:

- `Dashboard.jsx`: replaced its 3 inline `dayjs(...).format(...)` calls with `formatDate(...)`, keeping each call site's original format string (`"DD MMM YY"` for the scores table, `"DD MMM"` for date of birth, the default `"MMM D, YYYY"` for registered events).
- `EventCard.jsx` / `EventDetails.jsx`: replaced the `toLocaleDateString("en-IN", {...})` calls with `formatDate(date, "D MMM YYYY")`, which renders the same visible output.
- `AllEvents.jsx`: replaced the locale-dependent bare `toLocaleDateString()` with `formatDate(event.date, "D MMM YYYY")`, so it now renders consistently with the rest of the app instead of varying by browser locale.

## Verification

- `eslint` clean on all 5 touched files.
- `npm run build` compiles with no errors.
- Confirmed no remaining `dayjs` or `toLocaleDateString` usage outside the new utility (`grep -rn "toLocaleDateString|dayjs" src`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized date formatting across event cards, event details, dashboards, and event administration views.
  * Dates now appear in a consistent, readable format throughout the application.
  * Updated score, birth date, and registered-event date displays for a uniform experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->