### PR TITLE
fix: add timestamps to Score model

### DIFF
--- a/Athlead-client/src/pages/Dashboard.jsx
+++ b/Athlead-client/src/pages/Dashboard.jsx
@@ -127,7 +127,7 @@ const Dashboard = () => {
 
         const formattedScores = (scoresRes.data.scores || []).map((item) => ({
           ...item,
-          date: dayjs(item.date).format("DD MMM YY"),
+          date: dayjs(item.createdAt || item.date).format("DD MMM YY"),
         }));
 
         setScores(formattedScores);

--- a/Backend/models/Score.js
+++ b/Backend/models/Score.js
@@ -1,14 +1,17 @@
 import mongoose from "mongoose";
 
-const ScoreSchema = new mongoose.Schema({
-  user: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
-  date: {
-    type: Date,
-    default: Date.now,
-    expires: 60 * 60 * 24 * 30, // 30 days in seconds
+const ScoreSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    score: { type: Number, required: true },
   },
-  score: { type: Number, requied: true },
-});
+  {
+    timestamps: true,
+  },
+);
+
+// TTL: auto-delete scores 30 days after creation (replaces former `date` expires field)
+ScoreSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 30 });
 
 const Score = mongoose.model("Score", ScoreSchema);
 


### PR DESCRIPTION
## Summary
- Adds `timestamps: true` to the Score schema so documents get `createdAt` / `updatedAt`
- Fixes the `requied` typo and marks `user` / `score` as required
- Moves the 30-day TTL to an index on `createdAt` (replaces the old `date` field)
- Updates the dashboard chart to read `createdAt` (with a fallback to `date` for older docs)

Closes #105

## Test plan
- [x] Create a new score via `/api/score` and confirm the document has `createdAt` and `updatedAt`
- [x] Confirm `/api/my-scores` returns those fields
- [x] Open the dashboard score chart and verify dates still render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Score history now displays the correct creation date when available.
  - Improved score record validation to ensure required information is captured.
- **Data Management**
  - Score records now track creation and update times automatically.
  - Records older than 30 days are automatically removed, keeping score history current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->